### PR TITLE
fix: extend no-deprecated-classes to handle expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/parser": "6.19.0",
     "@typescript-eslint/rule-tester": "6.19.0",
     "bumpp": "9.3.0",
+    "debug": "4.3.4",
     "eslint": "8.56.0",
     "husky": "8.0.3",
     "lint-staged": "15.2.0",

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,3 @@
+export function removeDuplicates<T>(array: T[]): T[] {
+  return [...new Set(array)];
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,9 @@ export * from './compat';
 export * from './rule';
 
 export * from './visitor';
+
+export * from './node';
+
+export * from './config';
+
+export * from './array';

--- a/src/utils/node.ts
+++ b/src/utils/node.ts
@@ -1,0 +1,51 @@
+import type { ESLintNode } from 'vue-eslint-parser/ast/nodes';
+
+function getStringLiteralValue(node: ESLintNode, stringOnly: boolean = false) {
+  if (node.type === 'Literal') {
+    if (node.value == null) {
+      if (!stringOnly && node.bigint != null)
+        return node.bigint;
+
+      return null;
+    }
+    if (typeof node.value === 'string')
+      return node.value;
+
+    if (!stringOnly)
+      return String(node.value);
+
+    return null;
+  }
+  if (
+    node.type === 'TemplateLiteral'
+    && node.expressions.length === 0
+    && node.quasis.length === 1
+  )
+    return node.quasis[0].value.cooked;
+
+  return null;
+}
+
+export function getStaticPropertyName(node: ESLintNode) {
+  if (node.type === 'Property' || node.type === 'MethodDefinition') {
+    if (!node.computed) {
+      const key = node.key;
+      if (key.type === 'Identifier')
+        return key.name;
+    }
+    const key = node.key;
+    return getStringLiteralValue(key);
+  }
+  else if (node.type === 'MemberExpression') {
+    if (!node.computed) {
+      const property = node.property;
+      if (property.type === 'Identifier')
+        return property.name;
+
+      return null;
+    }
+    const property = node.property;
+    return getStringLiteralValue(property);
+  }
+  return null;
+}

--- a/tests/rules/no-deprecated-classes.ts
+++ b/tests/rules/no-deprecated-classes.ts
@@ -5,7 +5,7 @@ const vueParser = require.resolve('vue-eslint-parser');
 
 const tester = new RuleTester({
   parser: vueParser,
-  parserOptions: { ecmaVersion: 2015 },
+  parserOptions: { ecmaVersion: 2021, sourceType: 'module' },
 });
 
 tester.run(RULE_NAME, rule as never, {
@@ -70,6 +70,54 @@ tester.run(RULE_NAME, rule as never, {
       code: '<template><div class="text-uppercase"/></template>',
       output: '<template><div class="uppercase"/></template>',
       errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: `
+      <script>
+      export default {
+        data() {
+          return {
+            classA: 'align-self-center',
+            classB: 'text-uppercase',
+            enable: false
+          }
+        }
+      }
+      </script>
+      <template>
+        <div>
+          <span :class="['abc text-uppercase cl', classA]"/>
+          <span :class="{ 'abc text-uppercase cl': true, 'font-weight-bold': true, [classB]: true }"/>
+          <span :class="enable ? 'abc text-uppercase cl' : 'lower'"/>
+        </div>
+      </template>
+      `,
+      output: `
+      <script>
+      export default {
+        data() {
+          return {
+            classA: 'align-self-center',
+            classB: 'text-uppercase',
+            enable: false
+          }
+        }
+      }
+      </script>
+      <template>
+        <div>
+          <span :class="['abc uppercase cl', classA]"/>
+          <span :class="{ 'abc uppercase cl': true, 'font-bold': true, [classB]: true }"/>
+          <span :class="enable ? 'abc uppercase cl' : 'lower'"/>
+        </div>
+      </template>
+      `,
+      errors: [
+        { messageId: 'replacedWith' },
+        { messageId: 'replacedWith' },
+        { messageId: 'replacedWith' },
+        { messageId: 'replacedWith' },
+      ],
     },
   ],
 });


### PR DESCRIPTION
Closes #(issue_number)

The only thing that remains to make it perfect is to figure a way to go from the `Identifiers` in the template to the variable that is bound and update the value of the variable itself. But it needs more research.