### PR TITLE
feat: add writablePrefixes option to composable-return-readonly

### DIFF
--- a/docs/rules/composable-return-readonly.md
+++ b/docs/rules/composable-return-readonly.md
@@ -16,6 +16,8 @@ This rule requires that writable reactive variables (`ref`, `shallowRef`) return
 
 `computed()` refs are **excluded** because they are already readonly by design — wrapping them with `readonly()` is unnecessary. The rule will flag unnecessary `readonly()` usage on computed refs.
 
+Refs that are intentionally returned writable (for example, to bind with `v-model`) can be exempted by naming convention via the [`writablePrefixes`](#writableprefixes) option, instead of disabling the rule per line.
+
 <eslint-code-block fix>
 
 <!-- eslint-skip -->
@@ -44,7 +46,7 @@ function useCounter() {
 
 ```json
 {
-  "@rotki/composable-return-readonly": ["error", { "autofix": false }]
+  "@rotki/composable-return-readonly": ["error", { "autofix": false, "writablePrefixes": ["model"] }]
 }
 ```
 
@@ -54,6 +56,35 @@ function useCounter() {
 - Default: `false`
 
 When `true`, enables auto-fix via the `--fix` CLI flag. When `false` (default), the fix is available only as an editor suggestion.
+
+### `writablePrefixes`
+
+- Type: `string[]`
+- Default: `["model"]`
+
+Returned variables whose name starts with one of these prefixes are exempt from the `readonly()` requirement. Use this for refs you intentionally expose as writable — for example, a ref meant to be bound with `v-model` — so you don't need a per-line `eslint-disable`.
+
+Matching requires a strict camelCase boundary: the prefix must be the entire name or be followed by an uppercase letter. So `model` exempts `model` and `modelValue`, but **not** `models`.
+
+Providing this option **replaces** the default, so include the default value if you want to keep it alongside additions, e.g. `["model", "writable"]`.
+
+<eslint-code-block>
+
+<!-- eslint-skip -->
+
+```ts
+/* eslint @rotki/composable-return-readonly: ["error", { "writablePrefixes": ["model"] }] */
+
+function useInput() {
+  const modelValue = ref('');
+  const count = ref(0);
+
+  // ✓ GOOD — `modelValue` is exempt (writable by convention), `count` is wrapped
+  return { modelValue, count: readonly(count) };
+}
+```
+
+</eslint-code-block>
 
 ## :rocket: Version
 

--- a/src/rules/composable-return-readonly.ts
+++ b/src/rules/composable-return-readonly.ts
@@ -6,7 +6,9 @@ export const RULE_NAME = 'composable-return-readonly';
 
 export type MessageIds = 'suggestRemoveReadonly' | 'suggestWrapReadonly' | 'unnecessaryReadonly' | 'wrapReadonly';
 
-export type Options = [{ autofix?: boolean }];
+export type Options = [{ autofix?: boolean; writablePrefixes?: string[] }];
+
+const DEFAULT_WRITABLE_PREFIXES = ['model'];
 
 const REACTIVE_CREATORS = new Set(['ref', 'shallowRef']);
 const READONLY_CREATORS = new Set(['computed']);
@@ -22,9 +24,23 @@ function isReadonlyCall(node: TSESTree.Node): node is TSESTree.CallExpression & 
 export default createEslintRule<Options, MessageIds>({
   create(context) {
     const autofix = context.options[0]?.autofix ?? false;
+    const writablePrefixes = context.options[0]?.writablePrefixes ?? DEFAULT_WRITABLE_PREFIXES;
     const source = getSourceCode(context);
     const reactiveVars = new Set<string>();
     const readonlyVars = new Set<string>();
+
+    function isWritableByConvention(name: string): boolean {
+      return writablePrefixes.some((prefix) => {
+        if (!name.startsWith(prefix))
+          return false;
+
+        // Require a strict camelCase boundary: the prefix must be the whole name
+        // or be followed by an uppercase letter (e.g. `model` matches `model` and
+        // `modelValue`, but not `models`).
+        const next = name[prefix.length];
+        return next === undefined || (next >= 'A' && next <= 'Z');
+      });
+    }
 
     function reportWithFixOrSuggest(
       prop: TSESTree.Property,
@@ -59,10 +75,16 @@ export default createEslintRule<Options, MessageIds>({
     function checkMissingReadonly(prop: TSESTree.Property): void {
       if (prop.shorthand && prop.key.type === AST_NODE_TYPES.Identifier && reactiveVars.has(prop.key.name)) {
         const keyName = prop.key.name;
+        if (isWritableByConvention(keyName))
+          return;
+
         reportWithFixOrSuggest(prop, keyName, 'wrapReadonly', 'suggestWrapReadonly', fixer => fixer.replaceText(prop, `${keyName}: readonly(${keyName})`));
       }
       else if (!prop.shorthand && prop.value.type === AST_NODE_TYPES.Identifier && reactiveVars.has(prop.value.name)) {
         const valueName = prop.value.name;
+        if (isWritableByConvention(valueName))
+          return;
+
         reportWithFixOrSuggest(prop, valueName, 'wrapReadonly', 'suggestWrapReadonly', fixer => fixer.replaceText(prop.value, `readonly(${prop.value.type === AST_NODE_TYPES.Identifier ? prop.value.name : source.getText(prop.value)})`));
       }
     }
@@ -103,7 +125,7 @@ export default createEslintRule<Options, MessageIds>({
       },
     };
   },
-  defaultOptions: [{ autofix: false }],
+  defaultOptions: [{ autofix: false, writablePrefixes: DEFAULT_WRITABLE_PREFIXES }],
   meta: {
     docs: {
       description: 'Require returned refs from composables to be wrapped with readonly()',
@@ -125,6 +147,12 @@ export default createEslintRule<Options, MessageIds>({
             default: false,
             description: 'Enable auto-fix. When disabled, the fix is available as a suggestion.',
             type: 'boolean',
+          },
+          writablePrefixes: {
+            default: DEFAULT_WRITABLE_PREFIXES,
+            description: 'Returned variables whose name starts with one of these prefixes are exempt from the readonly() requirement (e.g. refs intended for v-model binding).',
+            items: { type: 'string' },
+            type: 'array',
           },
         },
         type: 'object',

--- a/tests/rules/composable-return-readonly.ts
+++ b/tests/rules/composable-return-readonly.ts
@@ -65,6 +65,37 @@ tester.run('composable-return-readonly', rule, {
         }
       `,
     },
+    {
+      // Default `model` prefix — writable by convention, should not flag (shorthand)
+      filename: 'test.ts',
+      code: `
+        function useInput() {
+          const modelValue = ref('');
+          return { modelValue };
+        }
+      `,
+    },
+    {
+      // Default `model` prefix — writable by convention, should not flag (non-shorthand value)
+      filename: 'test.ts',
+      code: `
+        function useInput() {
+          const modelText = ref('');
+          return { text: modelText };
+        }
+      `,
+    },
+    {
+      // Custom prefixes — `writable` exempt
+      filename: 'test.ts',
+      options: [{ writablePrefixes: ['writable'] }],
+      code: `
+        function useToggle() {
+          const writableActive = shallowRef(false);
+          return { writableActive };
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -158,6 +189,55 @@ tester.run('composable-return-readonly', rule, {
         }
       `,
       errors: [{ messageId: 'wrapReadonly' }],
+    },
+    // Custom writablePrefixes replaces the default — `model` is no longer exempt
+    {
+      filename: 'test.ts',
+      options: [{ writablePrefixes: ['writable'] }],
+      code: `
+        function useInput() {
+          const modelValue = ref('');
+          return { modelValue };
+        }
+      `,
+      errors: [{
+        messageId: 'wrapReadonly',
+        suggestions: [
+          {
+            messageId: 'suggestWrapReadonly',
+            output: `
+        function useInput() {
+          const modelValue = ref('');
+          return { modelValue: readonly(modelValue) };
+        }
+      `,
+          },
+        ],
+      }],
+    },
+    // Prefix without a camelCase boundary — `models` is not exempt by `model`
+    {
+      filename: 'test.ts',
+      code: `
+        function useList() {
+          const models = ref([]);
+          return { models };
+        }
+      `,
+      errors: [{
+        messageId: 'wrapReadonly',
+        suggestions: [
+          {
+            messageId: 'suggestWrapReadonly',
+            output: `
+        function useList() {
+          const models = ref([]);
+          return { models: readonly(models) };
+        }
+      `,
+          },
+        ],
+      }],
     },
     // Unnecessary readonly() on computed — should flag
     {


### PR DESCRIPTION
## Summary

Adds a `writablePrefixes` option to the `composable-return-readonly` rule so refs that are intentionally returned writable (e.g. for `v-model` binding) can be exempted by naming convention instead of a per-line `eslint-disable`.

- New option `writablePrefixes: string[]`, default `['model']`.
- A returned variable is exempt if its name matches a prefix with a **strict camelCase boundary** — the prefix must be the whole name or be followed by an uppercase letter. So `model` and `modelValue` are exempt, but `models` is not.
- Applies to both shorthand (`{ modelValue }`) and aliased (`{ text: modelText }`) return forms.
- Providing the option **replaces** the default (standard ESLint behavior); include `model` to keep it alongside additions.

## Test plan

- [x] `pnpm run test` — 146 passed
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- New tests cover: default `model` prefix (shorthand + aliased), custom prefix, default-replacement behavior, and the `models` non-boundary rejection.