### PR TITLE
feat: add no-redundant-flex-row rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,8 @@ export default [
 
 ## Rules
 
-| Rule                                                                                                         | Description                                                               | Fixable     |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- | ----------- |
-| [consistent-ref-type-annotation](https://rotki.github.io/eslint-plugin/rules/consistent-ref-type-annotation) | Ensures consistent type annotation position for ref, computed assignments | :black_nib: |
-| [max-dependencies](https://rotki.github.io/eslint-plugin/rules/max-dependencies)                             | Enforce a maximum number of dependencies per file                         |             |
-| [no-deprecated-classes](https://rotki.github.io/eslint-plugin/rules/no-deprecated-classes)                   | Disallow deprecated vuetify css classes                                   | :black_nib: |
-| [no-deprecated-components](https://rotki.github.io/eslint-plugin/rules/no-deprecated-components)             | Disallow deprecated components                                            | :black_nib: |
-| [no-deprecated-props](https://rotki.github.io/eslint-plugin/rules/no-deprecated-props)                       | Replace deprecated props with their replacements                          | :black_nib: |
-| [no-dot-ts-imports](https://rotki.github.io/eslint-plugin/rules/no-dot-ts-imports)                           | Disallow .ts extension in import statements                               | :black_nib: |
-| [no-legacy-library-import](https://rotki.github.io/eslint-plugin/rules/no-legacy-library-import)             | Disallow imports from @rotki/ui-library-compat                            | :black_nib: |
-| [no-unused-i18n-keys](https://rotki.github.io/eslint-plugin/rules/no-unused-i18n-keys)                       | Disallow unused i18n keys in locale files                                 | :black_nib: |
+See the [full list of available rules](https://rotki.github.io/eslint-plugin/rules/),
+including which are enabled by the `recommended` preset and which are auto-fixable.
 
 ## Documentation
 

--- a/docs/rules/composable-return-readonly.md
+++ b/docs/rules/composable-return-readonly.md
@@ -46,7 +46,10 @@ function useCounter() {
 
 ```json
 {
-  "@rotki/composable-return-readonly": ["error", { "autofix": false, "writablePrefixes": ["model"] }]
+  "@rotki/composable-return-readonly": [
+    "error",
+    { "autofix": false, "writablePrefixes": ["model"] }
+  ]
 }
 ```
 
@@ -68,7 +71,7 @@ Matching requires a strict camelCase boundary: the prefix must be the entire nam
 
 Providing this option **replaces** the default, so include the default value if you want to keep it alongside additions, e.g. `["model", "writable"]`.
 
-<eslint-code-block>
+<eslint-code-block fix>
 
 <!-- eslint-skip -->
 

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -15,6 +15,7 @@
 | [@rotki/<wbr>no-deprecated-props](./no-deprecated-props.html) | Replaces deprecated props with their replacements | :star::black_nib: |
 | [@rotki/<wbr>no-dot-ts-imports](./no-dot-ts-imports.html) | Checks and replaces .ts extension in import statements. | :star::black_nib: |
 | [@rotki/<wbr>no-legacy-library-import](./no-legacy-library-import.html) | Reports and replaces imports of @rotki/ui-library-compat with @rotki/ui-library | :star::black_nib: |
+| [@rotki/<wbr>no-redundant-flex-row](./no-redundant-flex-row.html) | disallow redundant `flex-row` since `flex` already defaults to the row direction | :star::black_nib: |
 | [@rotki/<wbr>no-unused-i18n-keys](./no-unused-i18n-keys.html) | disallow unused i18n keys in locale files | :star::black_nib: |
 
 ## strict

--- a/docs/rules/no-redundant-flex-row.md
+++ b/docs/rules/no-redundant-flex-row.md
@@ -1,0 +1,96 @@
+---
+title: '@rotki/no-redundant-flex-row'
+description: disallow redundant `flex-row` since `flex` already defaults to the row direction
+since: v1.4.0
+---
+
+# @rotki/no-redundant-flex-row
+
+> disallow redundant `flex-row` since `flex` already defaults to the row direction
+
+- :star: The `"extends": "plugin:@rotki/recommended"` property in a configuration file enables this rule.
+- :black_nib:️ The `--fix` option on the [command line](http://eslint.org/docs/user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+In Tailwind CSS, `flex` already lays children out in the row direction
+(`flex-direction: row` is the default). Pairing it with an unconditional
+`flex-row` therefore adds nothing — the `flex-row` class is dead weight.
+
+Directional classes only carry meaning when a **conditional variant** overrides a
+different base direction, e.g. an element that stacks vertically by default and
+becomes a row at the `sm` breakpoint (`flex flex-col sm:flex-row`).
+
+This rule reports an unconditional `flex-row` (or `inline-flex` + `flex-row`)
+and removes it on `--fix`.
+
+<eslint-code-block fix>
+
+<!-- eslint-skip -->
+
+```vue
+<script>
+/* eslint @rotki/no-redundant-flex-row: "error" */
+</script>
+
+<template>
+  <!-- ✓ GOOD -->
+  <div class="flex" />
+  <div class="flex flex-col sm:flex-row" />
+  <div class="flex sm:flex-row" />
+
+  <!-- ✗ BAD -->
+  <div class="flex flex-row" />
+  <div class="inline-flex flex-row" />
+  <div class="flex flex-row sm:flex-col" />
+</template>
+```
+
+</eslint-code-block>
+
+## :mag: Details
+
+- The rule only fires when an **unconditional** `flex` or `inline-flex` is present
+  alongside an **unconditional** `flex-row`. A variant prefix (`sm:`, `hover:`,
+  `dark:`, …) on either makes the combination meaningful, so it is never reported.
+- Tailwind's important modifier is recognised in both v3 (`!flex-row`) and
+  v4 (`flex-row!`) syntaxes.
+- Sibling utilities such as `flex-row-reverse`, `flex-wrap` and `flex-1` are
+  left untouched.
+- `flex-row` without a `flex`/`inline-flex` display class is **not** reported,
+  since the display might come from elsewhere and the rule stays conservative.
+
+### Dynamic `:class`
+
+Static `class` attributes and **plain string** `:class` bindings are linted —
+both `:class="'flex flex-row'"` and ``:class="`flex flex-row`"`` are reported.
+
+Object, array, ternary and interpolated `:class` bindings are intentionally
+**skipped**, because `flex-row` may be applied behind a runtime condition there
+rather than a variant prefix. The following are all left untouched:
+
+- `:class="{ 'flex-row': isRow }"` — applied only when `isRow` is truthy
+- `:class="['flex', isRow ? 'flex-row' : 'flex-col']"` — ternary branch
+- ``:class="`flex ${dir}`"`` — interpolated value
+
+Flagging these would risk silently auto-removing a meaningful conditional
+override (the object-syntax equivalent of `flex flex-col sm:flex-row`).
+
+## :gear: Options
+
+Nothing.
+
+```json
+{
+  "@rotki/no-redundant-flex-row": ["error"]
+}
+```
+
+## :rocket: Version
+
+This rule was introduced in `@rotki/eslint-plugin` v1.4.0
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/rotki/eslint-plugin/blob/master/src/rules/no-redundant-flex-row.ts)
+- [Test source](https://github.com/rotki/eslint-plugin/tree/master/tests/rules/no-redundant-flex-row.ts)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,6 +14,7 @@ import noDeprecatedComponents from './rules/no-deprecated-components';
 import noDeprecatedProps from './rules/no-deprecated-props';
 import noDotTsImport from './rules/no-dot-ts-imports';
 import noLegacyLibraryImport from './rules/no-legacy-library-import';
+import noRedundantFlexRow from './rules/no-redundant-flex-row';
 import noUnusedI18nKeys from './rules/no-unused-i18n-keys/index';
 import requireJsdocOnComposableOptions from './rules/require-jsdoc-on-composable-options';
 
@@ -37,6 +38,7 @@ const plugin = {
     'no-deprecated-props': noDeprecatedProps,
     'no-dot-ts-imports': noDotTsImport,
     'no-legacy-library-import': noLegacyLibraryImport,
+    'no-redundant-flex-row': noRedundantFlexRow,
     'no-unused-i18n-keys': noUnusedI18nKeys,
     'require-jsdoc-on-composable-options': requireJsdocOnComposableOptions,
   },

--- a/src/rules/no-redundant-flex-row.ts
+++ b/src/rules/no-redundant-flex-row.ts
@@ -1,0 +1,188 @@
+import type { AST as VAST } from 'vue-eslint-parser';
+import type { Range, RuleContext } from '../types';
+import debugFactory from 'debug';
+import { createEslintRule, defineTemplateBodyVisitor, getSourceCode } from '../utils';
+
+export const RULE_NAME = 'no-redundant-flex-row';
+
+export type MessageIds = 'redundantFlexRow';
+
+export type Options = [];
+
+const debug = debugFactory('@rotki/eslint-plugin:no-redundant-flex-row');
+
+/**
+ * A class list region that is statically known at lint time: the raw string of
+ * class names plus the source offset where that string's content begins.
+ */
+interface ClassListSource {
+  value: string;
+  /** Absolute source offset of the first character of `value`. */
+  contentStart: number;
+}
+
+/**
+ * Removes Tailwind's important modifier (`!flex-row` in v3, `flex-row!` in v4)
+ * so the bare utility can be compared.
+ */
+function stripImportant(token: string): string {
+  return token.replace(/^!/, '').replace(/!$/, '');
+}
+
+/**
+ * True when the token applies unconditionally, i.e. it carries no variant
+ * prefix such as `sm:`, `hover:` or `dark:`. Conditional variants are exactly
+ * what makes a directional class meaningful, so they are never reported.
+ */
+function isUnconditional(token: string): boolean {
+  return !token.includes(':');
+}
+
+function isFlexDisplay(token: string): boolean {
+  if (!isUnconditional(token))
+    return false;
+  const base = stripImportant(token);
+  return base === 'flex' || base === 'inline-flex';
+}
+
+function isFlexRow(token: string): boolean {
+  if (!isUnconditional(token))
+    return false;
+  return stripImportant(token) === 'flex-row';
+}
+
+interface Token {
+  text: string;
+  /** Index of the token within its class list string. */
+  start: number;
+}
+
+function tokenize(value: string): Token[] {
+  const tokens: Token[] = [];
+  const matcher = /\S+/g;
+  let match: RegExpExecArray | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((match = matcher.exec(value)) !== null)
+    tokens.push({ start: match.index, text: match[0] });
+  return tokens;
+}
+
+/**
+ * Computes the range to remove for a redundant token, swallowing exactly one
+ * run of adjacent whitespace (preferring the preceding whitespace) so the
+ * surrounding class list stays tidy after the fix.
+ */
+function removalRange(value: string, token: Token, contentStart: number): Range {
+  let startRel = token.start;
+  let endRel = token.start + token.text.length;
+
+  if (startRel > 0 && /\s/.test(value[startRel - 1])) {
+    while (startRel > 0 && /\s/.test(value[startRel - 1]))
+      startRel--;
+  }
+  else {
+    while (endRel < value.length && /\s/.test(value[endRel]))
+      endRel++;
+  }
+
+  return [contentStart + startRel, contentStart + endRel];
+}
+
+function reportRedundant(
+  source: ClassListSource,
+  context: RuleContext<MessageIds, Options>,
+  sourceCode: ReturnType<typeof getSourceCode>,
+): void {
+  const tokens = tokenize(source.value);
+  if (!tokens.some(token => isFlexDisplay(token.text)))
+    return;
+
+  for (const token of tokens) {
+    if (!isFlexRow(token.text))
+      continue;
+
+    debug(`found redundant flex-row token '${token.text}'`);
+
+    const tokenRange: Range = [
+      source.contentStart + token.start,
+      source.contentStart + token.start + token.text.length,
+    ];
+    const removal = removalRange(source.value, token, source.contentStart);
+
+    context.report({
+      data: { className: token.text },
+      fix(fixer) {
+        return fixer.removeRange(removal);
+      },
+      loc: {
+        end: sourceCode.getLocFromIndex(tokenRange[1]),
+        start: sourceCode.getLocFromIndex(tokenRange[0]),
+      },
+      messageId: 'redundantFlexRow',
+    });
+  }
+}
+
+/**
+ * Extracts statically-known class list strings from a `:class` expression.
+ * Only plain string literals (and single-quasi template literals with no
+ * interpolation) are considered: anything conditional — object syntax,
+ * arrays, ternaries or interpolated templates — is intentionally skipped,
+ * since `flex-row` may legitimately be applied behind a runtime condition.
+ */
+function plainStringLists(expression: NonNullable<VAST.VExpressionContainer['expression']>): ClassListSource[] {
+  if (expression.type === 'Literal' && typeof expression.value === 'string')
+    return [{ contentStart: expression.range[0] + 1, value: expression.value }];
+
+  if (
+    expression.type === 'TemplateLiteral'
+    && expression.expressions.length === 0
+    && expression.quasis.length === 1
+  ) {
+    const quasi = expression.quasis[0];
+    const cooked = quasi.value.cooked;
+    if (cooked !== null)
+      return [{ contentStart: quasi.range[0] + 1, value: cooked }];
+  }
+
+  return [];
+}
+
+export default createEslintRule<Options, MessageIds>({
+  create(context) {
+    const sourceCode = getSourceCode(context);
+    return defineTemplateBodyVisitor(context, {
+      'VAttribute[directive=false][key.name="class"]': function (node: VAST.VAttribute) {
+        if (!node.value || !node.value.value || !node.value.range)
+          return;
+
+        reportRedundant(
+          { contentStart: node.value.range[0] + 1, value: node.value.value },
+          context,
+          sourceCode,
+        );
+      },
+      'VAttribute[directive=true][key.name.name=\'bind\'][key.argument.name=\'class\'] > VExpressionContainer.value': function (node: VAST.VExpressionContainer) {
+        if (!node.expression)
+          return;
+
+        for (const source of plainStringLists(node.expression))
+          reportRedundant(source, context, sourceCode);
+      },
+    });
+  },
+  defaultOptions: [],
+  meta: {
+    docs: {
+      description: 'disallow redundant `flex-row` since `flex` already defaults to the row direction',
+      recommendation: 'recommended',
+    },
+    fixable: 'code',
+    messages: {
+      redundantFlexRow: `'{{ className }}' is redundant because 'flex' already lays out in the row direction; remove it, or keep it only behind a conditional variant (e.g. 'sm:flex-row')`,
+    },
+    schema: [],
+    type: 'suggestion',
+  },
+  name: RULE_NAME,
+});

--- a/tests/rules/no-redundant-flex-row.ts
+++ b/tests/rules/no-redundant-flex-row.ts
@@ -1,0 +1,95 @@
+import { RuleTester } from 'eslint';
+import vueParser from 'vue-eslint-parser';
+import rule, { RULE_NAME } from '../../src/rules/no-redundant-flex-row';
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: vueParser,
+    parserOptions: { ecmaVersion: 2021, sourceType: 'module' },
+  },
+});
+
+tester.run(RULE_NAME, rule, {
+  valid: [
+    // base column with a conditional override is the canonical good case
+    '<template><div class="flex flex-col sm:flex-row"/></template>',
+    // flex-row only appears behind a variant prefix
+    '<template><div class="flex sm:flex-row"/></template>',
+    '<template><div class="flex md:flex-row lg:flex-col"/></template>',
+    // flex-row without any flex display class is left alone (out of scope)
+    '<template><div class="flex-row"/></template>',
+    // unrelated flex utilities must not be matched
+    '<template><div class="flex flex-row-reverse"/></template>',
+    '<template><div class="flex flex-1 flex-wrap"/></template>',
+    '<template><div class="flex flex-col"/></template>',
+    '<template><div class="inline-flex flex-col"/></template>',
+    // conditional flex display + conditional row
+    '<template><div class="md:flex md:flex-row"/></template>',
+    // dynamic object/array/ternary bindings are intentionally skipped
+    '<template><div :class="{ \'flex-row\': isRow }" class="flex"/></template>',
+    '<template><div :class="[\'flex\', cond ? \'flex-row\' : \'flex-col\']"/></template>',
+    // eslint-disable-next-line no-template-curly-in-string -- fixture: interpolated template is skipped
+    '<template><div :class="`flex ${dir}`"/></template>',
+  ],
+  invalid: [
+    // the textbook redundancy
+    {
+      code: '<template><div class="flex flex-row"/></template>',
+      output: '<template><div class="flex"/></template>',
+      errors: [{ messageId: 'redundantFlexRow' }],
+    },
+    // order independent
+    {
+      code: '<template><div class="flex-row flex"/></template>',
+      output: '<template><div class="flex"/></template>',
+      errors: [{ messageId: 'redundantFlexRow' }],
+    },
+    // surrounded by other utilities
+    {
+      code: '<template><div class="p-4 flex flex-row items-center"/></template>',
+      output: '<template><div class="p-4 flex items-center"/></template>',
+      errors: [{ messageId: 'redundantFlexRow' }],
+    },
+    // inline-flex also defaults to row
+    {
+      code: '<template><div class="inline-flex flex-row"/></template>',
+      output: '<template><div class="inline-flex"/></template>',
+      errors: [{ messageId: 'redundantFlexRow' }],
+    },
+    // unconditional flex-row is redundant even when a conditional override exists
+    {
+      code: '<template><div class="flex flex-row sm:flex-col"/></template>',
+      output: '<template><div class="flex sm:flex-col"/></template>',
+      errors: [{ messageId: 'redundantFlexRow' }],
+    },
+    // important modifier, both v3 and v4 syntaxes
+    {
+      code: '<template><div class="flex !flex-row"/></template>',
+      output: '<template><div class="flex"/></template>',
+      errors: [{ messageId: 'redundantFlexRow' }],
+    },
+    {
+      code: '<template><div class="flex flex-row!"/></template>',
+      output: '<template><div class="flex"/></template>',
+      errors: [{ messageId: 'redundantFlexRow' }],
+    },
+    // multiple redundant tokens are each reported and removed
+    {
+      code: '<template><div class="flex flex-row gap-2 flex-row"/></template>',
+      output: '<template><div class="flex gap-2"/></template>',
+      errors: [{ messageId: 'redundantFlexRow' }, { messageId: 'redundantFlexRow' }],
+    },
+    // plain string :class binding
+    {
+      code: '<template><div :class="\'flex flex-row\'"/></template>',
+      output: '<template><div :class="\'flex\'"/></template>',
+      errors: [{ messageId: 'redundantFlexRow' }],
+    },
+    // single-quasi template literal :class binding
+    {
+      code: '<template><div :class="`flex flex-row`"/></template>',
+      output: '<template><div :class="`flex`"/></template>',
+      errors: [{ messageId: 'redundantFlexRow' }],
+    },
+  ],
+});


### PR DESCRIPTION
Closes #1

## Summary

Adds a new rule **`no-redundant-flex-row`** that flags an unconditional `flex-row` when an unconditional `flex`/`inline-flex` is also present, since `flex` already defaults to the row direction. The redundant class is auto-fixable (removed). Included in the `recommended` preset.

```html
<!-- ✗ redundant -->        <div class="flex flex-row" />        →  <div class="flex" />
<!-- ✗ base row is dead -->  <div class="flex flex-row sm:flex-col" />  →  <div class="flex sm:flex-col" />
<!-- ✓ meaningful -->        <div class="flex flex-col sm:flex-row" />
```

## Behaviour

- Reports only when **both** `flex`/`inline-flex` **and** `flex-row` are **unconditional** (no variant prefix). Any variant (`sm:`, `hover:`, `dark:`, …) makes the directional class meaningful and is never reported.
- Recognises Tailwind's important modifier in both v3 (`!flex-row`) and v4 (`flex-row!`) syntaxes.
- Leaves sibling utilities (`flex-row-reverse`, `flex-wrap`, `flex-1`) untouched.
- `flex-row` without a `flex`/`inline-flex` display class is **not** reported (conservative — display may come from elsewhere).

### Dynamic `:class`

Static `class` attributes and **plain-string** `:class` bindings (`'flex flex-row'`, `` `flex flex-row` ``) are linted. Object / array / ternary / interpolated bindings are **intentionally skipped**, because there the condition lives in JS (e.g. `:class="{ 'flex-row': isWide }"`) rather than a variant prefix, and flagging it would risk silently auto-removing a meaningful conditional override. This is purely additive and can be extended later.

## Changes

- `src/rules/no-redundant-flex-row.ts` + registration in `src/plugin.ts`
- `tests/rules/no-redundant-flex-row.ts` — 22 cases (12 valid / 10 invalid), full suite green (168 tests)
- `docs/rules/no-redundant-flex-row.md` (marked `since: v1.4.0`) + regenerated `docs/rules/index.md`
- README: replaced the hand-maintained rules table with a link to the docs site (it had already drifted out of date)

Docs mark the rule as introduced in **v1.4.0** (next minor; current is 1.3.2).