### PR TITLE
feat: exempt written-back params in composable-input-flexibility

### DIFF
--- a/docs/rules/composable-input-flexibility.md
+++ b/docs/rules/composable-input-flexibility.md
@@ -34,6 +34,31 @@ function useCounter(value: Ref<number>) {
 
 </eslint-code-block>
 
+## :white_check_mark: Written-back parameters are exempt
+
+A `MaybeRefOrGetter<T>` may be a plain getter, which is **not writable**. So a parameter
+that the composable writes back to must stay a `Ref<T>`, and the rule does not flag it.
+A parameter is considered written when it is reassigned via `set(param, …)`,
+`param.value = …` (including compound assignments), or an update expression such as
+`param.value++`.
+
+<!-- eslint-skip -->
+
+```ts
+/* eslint @rotki/composable-input-flexibility: "error" */
+
+// ✓ GOOD — `state` is written back, so a Ref is required and it is not flagged
+function useToggle(state: Ref<boolean>) {
+  function toggle() {
+    set(state, !get(state));
+  }
+  return { toggle };
+}
+```
+
+This means no inline `eslint-disable` is needed for writable parameters: only genuinely
+read-only `Ref<T>` parameters — where a getter would work just as well — are reported.
+
 ## :wrench: Options
 
 ```json

--- a/src/rules/composable-input-flexibility.ts
+++ b/src/rules/composable-input-flexibility.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, type TSESLint, type TSESTree } from '@typescript-eslint/utils';
 import { createEslintRule, isComposableName } from '../utils';
 
 export const RULE_NAME = 'composable-input-flexibility';
@@ -28,16 +28,64 @@ function checkParamForRef(param: TSESTree.Parameter): TSESTree.TSTypeReference |
   return undefined;
 }
 
+function getParamName(param: TSESTree.Parameter): string | undefined {
+  if (param.type === AST_NODE_TYPES.Identifier)
+    return param.name;
+
+  if (param.type === AST_NODE_TYPES.AssignmentPattern && param.left.type === AST_NODE_TYPES.Identifier)
+    return param.left.name;
+
+  return undefined;
+}
+
+/**
+ * A parameter reference is a write when it is reassigned via `set(param, …)`,
+ * `param.value = …` (including compound assignments) or an update expression
+ * such as `param.value++`. A getter passed via `MaybeRefOrGetter` is not
+ * writable, so such a parameter must stay a `Ref` and should not be flagged.
+ */
+function isWriteReference(reference: TSESLint.Scope.Reference): boolean {
+  const { identifier } = reference;
+  const parent = identifier.parent;
+
+  // set(param, …)
+  if (parent.type === AST_NODE_TYPES.CallExpression) {
+    return parent.callee.type === AST_NODE_TYPES.Identifier
+      && parent.callee.name === 'set'
+      && parent.arguments[0] === identifier;
+  }
+
+  // param.value on the left of an assignment or in an update expression
+  if (parent.type === AST_NODE_TYPES.MemberExpression
+    && parent.object === identifier
+    && !parent.computed
+    && parent.property.type === AST_NODE_TYPES.Identifier
+    && parent.property.name === 'value') {
+    const grandparent = parent.parent;
+    if (grandparent.type === AST_NODE_TYPES.AssignmentExpression)
+      return grandparent.left === parent;
+
+    return grandparent.type === AST_NODE_TYPES.UpdateExpression;
+  }
+
+  return false;
+}
+
+function isWrittenParam(scope: TSESLint.Scope.Scope, name: string): boolean {
+  const variable = scope.variables.find(candidate => candidate.name === name);
+  return variable?.references.some(isWriteReference) ?? false;
+}
+
 export default createEslintRule<Options, MessageIds>({
   create(context) {
     const autofix = context.options[0]?.autofix ?? false;
 
     return {
       FunctionDeclaration: (node: TSESTree.FunctionDeclaration) => {
-        if (!node.id || !isComposableName(node.id.name))
+        if (!node.id || !isComposableName(node.id.name) || !node.body)
           return;
 
-        checkParams(node.params);
+        checkParams(node.params, node);
       },
       VariableDeclarator: (node: TSESTree.VariableDeclarator) => {
         if (node.id.type !== AST_NODE_TYPES.Identifier || !isComposableName(node.id.name))
@@ -45,34 +93,42 @@ export default createEslintRule<Options, MessageIds>({
 
         if (node.init?.type === AST_NODE_TYPES.ArrowFunctionExpression
           || node.init?.type === AST_NODE_TYPES.FunctionExpression) {
-          checkParams(node.init.params);
+          checkParams(node.init.params, node.init);
         }
       },
     };
 
-    function checkParams(params: TSESTree.Parameter[]) {
+    function checkParams(params: TSESTree.Parameter[], fn: TSESTree.FunctionLike) {
+      const scope = context.sourceCode.getScope(fn);
+
       for (const param of params) {
         const refType = checkParamForRef(param);
-        if (refType) {
-          context.report({
-            ...(autofix
-              ? {
+        if (!refType)
+          continue;
+
+        // Escape hatch: a parameter written back to must stay a writable Ref.
+        const name = getParamName(param);
+        if (name && isWrittenParam(scope, name))
+          continue;
+
+        context.report({
+          ...(autofix
+            ? {
+                fix(fixer) {
+                  return fixer.replaceText(refType.typeName, 'MaybeRefOrGetter');
+                },
+              }
+            : {
+                suggest: [{
                   fix(fixer) {
                     return fixer.replaceText(refType.typeName, 'MaybeRefOrGetter');
                   },
-                }
-              : {
-                  suggest: [{
-                    fix(fixer) {
-                      return fixer.replaceText(refType.typeName, 'MaybeRefOrGetter');
-                    },
-                    messageId: 'suggestMaybeRefOrGetter',
-                  }],
-                }),
-            messageId: 'preferMaybeRefOrGetter',
-            node: refType,
-          });
-        }
+                  messageId: 'suggestMaybeRefOrGetter',
+                }],
+              }),
+          messageId: 'preferMaybeRefOrGetter',
+          node: refType,
+        });
       }
     }
   },

--- a/tests/rules/composable-input-flexibility.ts
+++ b/tests/rules/composable-input-flexibility.ts
@@ -40,6 +40,64 @@ tester.run('composable-input-flexibility', rule, {
         }
       `,
     },
+    {
+      // Written back via set() — must stay a writable Ref
+      filename: 'test.ts',
+      code: `
+        function useToggle(state: Ref<boolean>) {
+          function toggle() {
+            set(state, !get(state));
+          }
+          return { toggle };
+        }
+      `,
+    },
+    {
+      // Written back via .value assignment — must stay a writable Ref
+      filename: 'test.ts',
+      code: `
+        function useCounter(count: Ref<number>) {
+          function reset() {
+            count.value = 0;
+          }
+          return { reset };
+        }
+      `,
+    },
+    {
+      // Written back via update expression — must stay a writable Ref
+      filename: 'test.ts',
+      code: `
+        function useCounter(count: Ref<number>) {
+          function increment() {
+            count.value++;
+          }
+          return { increment };
+        }
+      `,
+    },
+    {
+      // Written back via compound assignment — must stay a writable Ref
+      filename: 'test.ts',
+      code: `
+        function useCounter(count: Ref<number>) {
+          function add(n: number) {
+            count.value += n;
+          }
+          return { add };
+        }
+      `,
+    },
+    {
+      // Arrow composable, written back via set()
+      filename: 'test.ts',
+      code: `
+        const useThing = (writable: Ref<number>) => {
+          set(writable, 1);
+          return { writable };
+        };
+      `,
+    },
   ],
   invalid: [
     {
@@ -79,6 +137,30 @@ tester.run('composable-input-flexibility', rule, {
         const useLabel = (text: MaybeRefOrGetter<string>) => {
           return { label: text };
         };
+      `,
+          },
+        ],
+      }],
+    },
+    {
+      // Mixed params: read-only `label` is flagged, written-back `count` is exempt
+      filename: 'test.ts',
+      code: `
+        function useThing(label: Ref<string>, count: Ref<number>) {
+          set(count, 1);
+          return { label, count };
+        }
+      `,
+      errors: [{
+        messageId: 'preferMaybeRefOrGetter',
+        suggestions: [
+          {
+            messageId: 'suggestMaybeRefOrGetter',
+            output: `
+        function useThing(label: MaybeRefOrGetter<string>, count: Ref<number>) {
+          set(count, 1);
+          return { label, count };
+        }
       `,
           },
         ],


### PR DESCRIPTION
## Summary

`composable-input-flexibility` currently flags **every** `Ref<T>` composable parameter, including ones the composable writes back to. But `MaybeRefOrGetter<T>` may be a plain getter, which is **not writable** — so a parameter reassigned inside the composable must stay a `Ref<T>`. Those reports are false positives that can only be silenced with an inline `eslint-disable`.

This adds an automatic escape hatch: a parameter is exempt when it is written back within the composable body.

## What counts as a write

Detected via scope analysis on the parameter's references:

- `set(param, …)` (VueUse)
- `param.value = …` (including compound assignments like `+=`)
- update expressions: `param.value++`, `--param.value`

Read-only `Ref<T>` params — where a getter would work just as well — are still reported.

## Why write-detection (not a naming option like `writablePrefixes`)

The sibling `composable-return-readonly` rule uses a naming-prefix option because the write happens in the **caller** and isn't visible to the rule. Here the write happens in the **composable's own body**, so it can be detected directly — no naming convention or configuration needed.

## Testing

- 6 new test cases: `set()`, `.value =`, `.value++`, compound assignment, arrow-composable write, and a mixed multi-param case (read-only param flagged, written param exempt).
- Full suite green (174 tests), `eslint .` clean, `unbuild` succeeds.
- Docs updated with a "Written-back parameters are exempt" section.