### PR TITLE
feat: add no-shared-pinia rule

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -16,6 +16,7 @@
 | [@rotki/<wbr>no-dot-ts-imports](./no-dot-ts-imports.html) | Checks and replaces .ts extension in import statements. | :star::black_nib: |
 | [@rotki/<wbr>no-legacy-library-import](./no-legacy-library-import.html) | Reports and replaces imports of @rotki/ui-library-compat with @rotki/ui-library | :star::black_nib: |
 | [@rotki/<wbr>no-redundant-flex-row](./no-redundant-flex-row.html) | disallow redundant `flex-row` since `flex` already defaults to the row direction | :star::black_nib: |
+| [@rotki/<wbr>no-shared-pinia](./no-shared-pinia.html) | disallow a Pinia instance shared across tests via `describe`-body or module scope | :star: |
 | [@rotki/<wbr>no-unused-i18n-keys](./no-unused-i18n-keys.html) | disallow unused i18n keys in locale files | :star::black_nib: |
 
 ## strict

--- a/docs/rules/no-shared-pinia.md
+++ b/docs/rules/no-shared-pinia.md
@@ -1,0 +1,95 @@
+---
+title: '@rotki/no-shared-pinia'
+description: disallow a Pinia instance shared across tests via `describe`-body or module scope
+since: v1.5.0
+---
+
+# @rotki/no-shared-pinia
+
+> disallow a Pinia instance shared across tests via `describe`-body or module scope
+
+- :star: The `"extends": "plugin:@rotki/recommended"` property in a configuration file enables this rule.
+
+## :book: Rule Details
+
+A Pinia instance created **once in the `describe` body** (or at module scope) is reused by every `it` in that suite. Because the instance is shared, a store mutated in one test is still mutated in the next: specs pass in file order but fail (or pass for the wrong reason) under `--sequence.shuffle`. This is a real, latent, order-dependent bug class.
+
+The safe pattern is a **fresh instance per test**: `setActivePinia(createPinia())` (or the repo's `createCustomPinia()` helper) inside `beforeEach`, not in the `describe` body.
+
+This rule only runs on test files (`*.spec.ts` / `*.test.ts` by default). It reports when a tracked factory (`createPinia`, `createCustomPinia`, `createTestingPinia`) is called directly in a `describe` body or at module scope and there is **no** `beforeEach` in the same suite that re-creates a fresh instance. Only `beforeEach` clears the report: a `beforeAll` runs once, and a `beforeEach` that merely re-activates the same shared instance still leaks state.
+
+The rule tracks where the factory is **called**, not where the variable is declared. A `let pinia` binding in the `describe` body whose `createX()` assignment happens inside `beforeEach` is fine.
+
+<!-- eslint-skip -->
+
+```ts
+/* eslint @rotki/no-shared-pinia: "error" */
+
+// ✗ BAD: shared across every test, state bleeds
+describe('useThing', () => {
+  setActivePinia(createPinia());
+  it('a', () => {
+    /* mutates store */
+  });
+  it('b', () => {
+    /* sees a's mutation */
+  });
+});
+
+// ✗ BAD: a beforeEach that re-activates the SAME instance is still shared
+describe('useThing', () => {
+  const pinia = createPinia();
+  beforeEach(() => setActivePinia(pinia));
+  it('a', () => {});
+});
+
+// ✓ GOOD: fresh instance per test
+describe('useThing', () => {
+  beforeEach(() => setActivePinia(createCustomPinia()));
+  it('a', () => {});
+  it('b', () => {});
+});
+```
+
+Some shared instances are intentional (singleton composables under test via `createSharedComposable`, module-level singletons). For those, opt out with an inline disable:
+
+<!-- eslint-skip -->
+
+```ts
+describe('useSingleton', () => {
+  // eslint-disable-next-line @rotki/no-shared-pinia -- intentional singleton under test
+  setActivePinia(createPinia());
+  it('a', () => {});
+});
+```
+
+## :gear: Options
+
+```json
+{
+  "@rotki/no-shared-pinia": [
+    "error",
+    {
+      "factories": ["createPinia", "createCustomPinia", "createTestingPinia"],
+      "testFilePattern": "\\.(spec|test)\\.[cm]?[jt]sx?$"
+    }
+  ]
+}
+```
+
+### `factories` (string[])
+
+The creation calls to track. Default `["createPinia", "createCustomPinia", "createTestingPinia"]`.
+
+### `testFilePattern` (string)
+
+A regular-expression source string matched against the file name to decide whether a file is a test file. Files that do not match are ignored. Default `"\\.(spec|test)\\.[cm]?[jt]sx?$"`.
+
+## :rocket: Version
+
+This rule was introduced in `@rotki/eslint-plugin` v1.5.0
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/rotki/eslint-plugin/blob/master/src/rules/no-shared-pinia.ts)
+- [Test source](https://github.com/rotki/eslint-plugin/tree/master/tests/rules/no-shared-pinia.ts)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -15,6 +15,7 @@ import noDeprecatedProps from './rules/no-deprecated-props';
 import noDotTsImport from './rules/no-dot-ts-imports';
 import noLegacyLibraryImport from './rules/no-legacy-library-import';
 import noRedundantFlexRow from './rules/no-redundant-flex-row';
+import noSharedPinia from './rules/no-shared-pinia';
 import noUnusedI18nKeys from './rules/no-unused-i18n-keys/index';
 import requireJsdocOnComposableOptions from './rules/require-jsdoc-on-composable-options';
 
@@ -39,6 +40,7 @@ const plugin = {
     'no-dot-ts-imports': noDotTsImport,
     'no-legacy-library-import': noLegacyLibraryImport,
     'no-redundant-flex-row': noRedundantFlexRow,
+    'no-shared-pinia': noSharedPinia,
     'no-unused-i18n-keys': noUnusedI18nKeys,
     'require-jsdoc-on-composable-options': requireJsdocOnComposableOptions,
   },

--- a/src/rules/no-shared-pinia.ts
+++ b/src/rules/no-shared-pinia.ts
@@ -1,0 +1,224 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import debugFactory from 'debug';
+import { createEslintRule, getFilename } from '../utils';
+
+export const RULE_NAME = 'no-shared-pinia';
+
+export type MessageIds = 'sharedPinia';
+
+export interface Options {
+  factories: string[];
+  testFilePattern: string;
+}
+
+const debug = debugFactory('@rotki/eslint-plugin:no-shared-pinia');
+
+type FunctionNode =
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression
+  | TSESTree.ArrowFunctionExpression;
+
+/** The container a creation is scoped to: a `describe` callback, or the module. */
+type Container = FunctionNode | TSESTree.Program;
+
+const DESCRIBE_NAMES = new Set(['describe', 'fdescribe', 'xdescribe', 'suite']);
+const BEFORE_EACH_NAMES = new Set(['beforeEach']);
+
+const DEFAULT_FACTORIES = ['createPinia', 'createCustomPinia', 'createTestingPinia'];
+const DEFAULT_TEST_FILE_PATTERN = '\\.(spec|test)\\.[cm]?[jt]sx?$';
+
+function isFunctionNode(node: TSESTree.Node): node is FunctionNode {
+  return (
+    node.type === 'FunctionDeclaration'
+    || node.type === 'FunctionExpression'
+    || node.type === 'ArrowFunctionExpression'
+  );
+}
+
+/**
+ * Resolves the base identifier name a call ultimately targets, unwrapping
+ * member chains (`describe.only`, `describe.skip`) and curried calls
+ * (`describe.each([...])(...)`). Returns `null` when the callee is not an
+ * identifier-rooted call.
+ */
+function getRootCalleeName(callee: TSESTree.Node): string | null {
+  if (callee.type === 'Identifier')
+    return callee.name;
+  if (callee.type === 'MemberExpression')
+    return getRootCalleeName(callee.object);
+  if (callee.type === 'CallExpression')
+    return getRootCalleeName(callee.callee);
+  return null;
+}
+
+/**
+ * When `fn` is a callback argument of a call, returns the base name of that
+ * call (e.g. `describe`, `beforeEach`). Returns `null` otherwise.
+ */
+function callbackOwnerName(fn: FunctionNode): string | null {
+  const parent = fn.parent;
+  if (!parent || parent.type !== 'CallExpression')
+    return null;
+  return getRootCalleeName(parent.callee);
+}
+
+/** True when `fn` is the callback argument of a `beforeEach(...)` call. */
+function isBeforeEachCallback(fn: FunctionNode): boolean {
+  const owner = callbackOwnerName(fn);
+  return owner != null && BEFORE_EACH_NAMES.has(owner);
+}
+
+/** True when `fn` is the callback argument of a `describe(...)` call. */
+function isDescribeCallback(fn: FunctionNode): boolean {
+  const owner = callbackOwnerName(fn);
+  return owner != null && DESCRIBE_NAMES.has(owner);
+}
+
+/**
+ * Walks up from `node` to the nearest enclosing function. Returns `null` when
+ * the node lives at module top level.
+ */
+function nearestFunction(node: TSESTree.Node): FunctionNode | null {
+  let current: TSESTree.Node | undefined = node.parent;
+  while (current) {
+    if (isFunctionNode(current))
+      return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function buildTestFileMatcher(pattern: string): (filename: string) => boolean {
+  const regex = new RegExp(pattern, 'u');
+  return filename => regex.test(filename);
+}
+
+interface Candidate {
+  node: TSESTree.CallExpression;
+  container: Container;
+  factory: string;
+  atModuleScope: boolean;
+}
+
+export default createEslintRule<[Options], MessageIds>({
+  create(context, optionsWithDefault) {
+    const options: Partial<Options> = optionsWithDefault[0] ?? {};
+    const factories = new Set(options.factories ?? DEFAULT_FACTORIES);
+    const isTestFile = buildTestFileMatcher(options.testFilePattern ?? DEFAULT_TEST_FILE_PATTERN);
+    const filename = getFilename(context);
+
+    if (!isTestFile(filename)) {
+      debug(`skipping non-test file '${filename}'`);
+      return {};
+    }
+
+    let program: TSESTree.Program | null = null;
+    // Creations that are shared across every test unless a sibling `beforeEach`
+    // re-creates a fresh instance.
+    const candidates: Candidate[] = [];
+    // Containers (`describe` callbacks or the module) whose tests DO get a fresh
+    // instance because a `beforeEach` in them re-creates one.
+    const freshContainers = new Set<Container>();
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        const name = getRootCalleeName(node.callee);
+        if (name == null || !factories.has(name) || program == null)
+          return;
+
+        const enclosing = nearestFunction(node);
+
+        // A factory call inside a `beforeEach` produces a fresh instance per
+        // test. Mark the container that owns that `beforeEach` as safe. Only
+        // `beforeEach` counts: `beforeAll` runs once, so reusing its instance
+        // still leaks state between tests.
+        if (enclosing != null && isBeforeEachCallback(enclosing)) {
+          freshContainers.add(nearestFunction(enclosing) ?? program);
+          return;
+        }
+
+        // A creation living directly in a `describe` body (or at module scope)
+        // is shared across every test; anything else (inside `it`, an
+        // `afterEach`, or a helper) is per-call and left alone.
+        if (enclosing != null && !isDescribeCallback(enclosing))
+          return;
+
+        candidates.push({
+          atModuleScope: enclosing == null,
+          container: enclosing ?? program,
+          factory: name,
+          node,
+        });
+      },
+      Program(node: TSESTree.Program) {
+        program = node;
+      },
+      'Program:exit': function () {
+        // A `beforeEach` in an ancestor `describe` (or at module scope) runs
+        // before every test in nested suites, so it protects a creation in a
+        // descendant container too. Walk up the nesting looking for any fresh
+        // ancestor. Safety only propagates downward: a child `beforeEach` never
+        // protects a parent-scoped creation.
+        const isProtected = (container: Container): boolean => {
+          let current: Container | null = container;
+          while (current != null) {
+            if (freshContainers.has(current))
+              return true;
+            if (current.type === 'Program')
+              break;
+            current = nearestFunction(current) ?? program;
+          }
+          return false;
+        };
+
+        for (const candidate of candidates) {
+          if (isProtected(candidate.container))
+            continue;
+
+          debug(`found shared pinia via '${candidate.factory}' ${candidate.atModuleScope ? 'at module scope' : 'in describe body'}`);
+
+          context.report({
+            data: {
+              factory: candidate.factory,
+              location: candidate.atModuleScope ? 'at module scope' : 'in the `describe` body',
+            },
+            messageId: 'sharedPinia',
+            node: candidate.node,
+          });
+        }
+      },
+    };
+  },
+  defaultOptions: [
+    {
+      factories: DEFAULT_FACTORIES,
+      testFilePattern: DEFAULT_TEST_FILE_PATTERN,
+    },
+  ],
+  meta: {
+    docs: {
+      description: 'disallow a Pinia instance shared across tests via `describe`-body or module scope',
+      recommendation: 'recommended',
+    },
+    messages: {
+      sharedPinia: '`{{ factory }}()` is called {{ location }}, so the Pinia instance is shared across every test and store state leaks between them. Create a fresh instance per test with `beforeEach(() => setActivePinia(createPinia()))`, or add an inline disable if the shared instance is intentional.',
+    },
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          factories: {
+            items: { type: 'string' },
+            type: 'array',
+          },
+          testFilePattern: {
+            type: 'string',
+          },
+        },
+        type: 'object',
+      },
+    ],
+    type: 'problem',
+  },
+  name: RULE_NAME,
+});

--- a/tests/rules/no-shared-pinia.ts
+++ b/tests/rules/no-shared-pinia.ts
@@ -1,0 +1,236 @@
+import { RuleTester } from 'eslint';
+import vueParser from 'vue-eslint-parser';
+import rule, { RULE_NAME } from '../../src/rules/no-shared-pinia';
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: vueParser,
+    parserOptions: {
+      ecmaVersion: 2021,
+      parser: '@typescript-eslint/parser',
+      sourceType: 'module',
+    },
+  },
+});
+
+tester.run(RULE_NAME, rule, {
+  invalid: [
+    // setActivePinia(createPinia()) directly in the describe body
+    {
+      code: `
+        describe('useThing', () => {
+          setActivePinia(createPinia());
+          it('a', () => {});
+          it('b', () => {});
+        });
+      `,
+      errors: [{ messageId: 'sharedPinia' }],
+      filename: 'thing.spec.ts',
+    },
+    // instance assigned to a variable in the describe body
+    {
+      code: `
+        describe('useThing', () => {
+          const pinia = createCustomPinia();
+          setActivePinia(pinia);
+          it('a', () => {});
+        });
+      `,
+      errors: [{ messageId: 'sharedPinia' }],
+      filename: 'thing.spec.ts',
+    },
+    // createTestingPinia shared in the describe body
+    {
+      code: `
+        describe('Component', () => {
+          const pinia = createTestingPinia();
+          it('renders', () => {});
+        });
+      `,
+      errors: [{ messageId: 'sharedPinia' }],
+      filename: 'component.test.ts',
+    },
+    // a beforeEach that only re-activates the SAME instance is still shared
+    {
+      code: `
+        describe('useThing', () => {
+          const pinia = createPinia();
+          beforeEach(() => setActivePinia(pinia));
+          it('a', () => {});
+        });
+      `,
+      errors: [{ messageId: 'sharedPinia' }],
+      filename: 'thing.spec.ts',
+    },
+    // module top-level creation
+    {
+      code: `
+        setActivePinia(createPinia());
+        describe('useThing', () => {
+          it('a', () => {});
+        });
+      `,
+      errors: [{ messageId: 'sharedPinia' }],
+      filename: 'thing.spec.ts',
+    },
+    // describe.only variant is still a describe body
+    {
+      code: `
+        describe.only('useThing', () => {
+          setActivePinia(createPinia());
+          it('a', () => {});
+        });
+      `,
+      errors: [{ messageId: 'sharedPinia' }],
+      filename: 'thing.spec.ts',
+    },
+    // vitest `suite` alias and a plain function callback
+    {
+      code: `
+        suite('useThing', function () {
+          setActivePinia(createPinia());
+          it('a', () => {});
+        });
+      `,
+      errors: [{ messageId: 'sharedPinia' }],
+      filename: 'thing.spec.ts',
+    },
+    // a child beforeEach does NOT protect a parent-scoped creation
+    {
+      code: `
+        describe('outer', () => {
+          setActivePinia(createPinia());
+          it('direct', () => {});
+          describe('inner', () => {
+            beforeEach(() => setActivePinia(createPinia()));
+            it('a', () => {});
+          });
+        });
+      `,
+      errors: [{ messageId: 'sharedPinia' }],
+      filename: 'thing.spec.ts',
+    },
+    // beforeAll does not make it per-test; body creation still flagged
+    {
+      code: `
+        describe('useThing', () => {
+          const pinia = createPinia();
+          beforeAll(() => setActivePinia(pinia));
+          it('a', () => {});
+        });
+      `,
+      errors: [{ messageId: 'sharedPinia' }],
+      filename: 'thing.spec.ts',
+    },
+  ],
+  valid: [
+    // fresh instance per test in beforeEach
+    {
+      code: `
+        describe('useThing', () => {
+          beforeEach(() => setActivePinia(createCustomPinia()));
+          it('a', () => {});
+          it('b', () => {});
+        });
+      `,
+      filename: 'thing.spec.ts',
+    },
+    // creation inside beforeEach block body
+    {
+      code: `
+        describe('useThing', () => {
+          beforeEach(() => {
+            setActivePinia(createPinia());
+          });
+          it('a', () => {});
+        });
+      `,
+      filename: 'thing.spec.ts',
+    },
+    // describe-body creation IS present but a beforeEach re-creates a fresh one
+    {
+      code: `
+        describe('useThing', () => {
+          let pinia = createPinia();
+          beforeEach(() => {
+            pinia = createPinia();
+            setActivePinia(pinia);
+          });
+          it('a', () => {});
+        });
+      `,
+      filename: 'thing.spec.ts',
+    },
+    // variable declared in describe body, but created fresh inside beforeEach
+    {
+      code: `
+        describe('useThing', () => {
+          let pinia: Pinia;
+          beforeEach(() => {
+            pinia = createPinia();
+            setActivePinia(pinia);
+          });
+          it('a', () => {});
+        });
+      `,
+      filename: 'thing.spec.ts',
+    },
+    // creation inside an it callback
+    {
+      code: `
+        describe('useThing', () => {
+          it('a', () => {
+            setActivePinia(createPinia());
+          });
+        });
+      `,
+      filename: 'thing.spec.ts',
+    },
+    // not a test file: rule does not apply
+    {
+      code: `
+        describe('useThing', () => {
+          setActivePinia(createPinia());
+          it('a', () => {});
+        });
+      `,
+      filename: 'thing.ts',
+    },
+    // inner describe has its own beforeEach; outer beforeEach re-creates fresh
+    {
+      code: `
+        describe('outer', () => {
+          beforeEach(() => setActivePinia(createPinia()));
+          describe('inner', () => {
+            it('a', () => {});
+          });
+        });
+      `,
+      filename: 'thing.spec.ts',
+    },
+    // an ancestor beforeEach protects a creation in a nested describe body
+    {
+      code: `
+        describe('outer', () => {
+          beforeEach(() => setActivePinia(createPinia()));
+          describe('inner', () => {
+            const pinia = createTestingPinia();
+            it('a', () => {});
+          });
+        });
+      `,
+      filename: 'thing.spec.ts',
+    },
+    // a top-level beforeEach protects a describe-body creation
+    {
+      code: `
+        beforeEach(() => setActivePinia(createPinia()));
+        describe('useThing', () => {
+          const pinia = createTestingPinia();
+          it('a', () => {});
+        });
+      `,
+      filename: 'thing.spec.ts',
+    },
+  ],
+});


### PR DESCRIPTION
Closes #41.

Adds a `no-shared-pinia` rule that flags a Pinia instance created once in a `describe` body (or at module scope) and reused across every test. A shared instance leaks store state between tests, so specs pass in file order but fail (or pass for the wrong reason) under `--sequence.shuffle`.

## Behaviour

- Runs on test files only (`*.spec.ts` / `*.test.ts` by default; overridable via `testFilePattern`).
- Tracks where the **factory is called**, not where the variable is declared. `let pinia` in the `describe` body with `pinia = createPinia()` inside `beforeEach` is fine.
- Reports a describe-body / module-scope creation only when **no** `beforeEach` re-creates a fresh instance. Hook inheritance is respected: a `beforeEach` in an ancestor `describe` or at module top level protects nested creations (safety propagates downward only).
- Only `beforeEach` clears the report. A `beforeAll` runs once, and a `beforeEach` that merely re-activates the *same* instance still leaks state, so both are still flagged.
- Tracked factories default to `createPinia`, `createCustomPinia`, `createTestingPinia` (configurable via `factories`).
- Recognises `describe` / `fdescribe` / `xdescribe` / `suite` and both arrow and `function` callbacks.
- Intentional singletons (e.g. `createSharedComposable` under test) opt out via an inline `eslint-disable`.

No autofix, per the issue (report-only is already valuable and an autofix risks clobbering an existing `beforeEach`).

## Options

\`\`\`json
{
  "@rotki/no-shared-pinia": ["error", {
    "factories": ["createPinia", "createCustomPinia", "createTestingPinia"],
    "testFilePattern": "\\.(spec|test)\\.[cm]?[jt]sx?$"
  }]
}
\`\`\`

Enabled by the `recommended` preset, consistent with the other rules.

## Tests

18 cases covering the issue's examples plus `describe.only`, `suite`, module scope, `beforeAll`, nested-describe hook inheritance (both directions), the reactivate-same-instance trap, and non-test-file exclusion. Full suite (192 tests), typecheck, lint, and build all pass.